### PR TITLE
Feature/meds 1135 cosmos database

### DIFF
--- a/src/apis/Inss.FormsSubmission.Service/IPUpload/Extensions/ServiceCollectionExtensions.cs
+++ b/src/apis/Inss.FormsSubmission.Service/IPUpload/Extensions/ServiceCollectionExtensions.cs
@@ -35,12 +35,24 @@ internal static class ServiceCollectionExtensions
                 CosmosDbOptions cosmosDbOptions = new();
                 context.Configuration.GetSection("CosmosDb").Bind(cosmosDbOptions);
                 
-                CosmosClientOptions options = new() { Serializer = new CosmosModelSerializer() };
-                CosmosClient cosmosClient = cosmosDbOptions.ConnectionString is not null
-                    ? new CosmosClient(cosmosDbOptions.ConnectionString, options)
-                    : new CosmosClient(cosmosDbOptions.AccountEndpoint, new DefaultAzureCredential(), options);
-                services.AddTransient<IDynamicsStoreProvider>(
+                if (!string.IsNullOrWhiteSpace(cosmosDbOptions.ConnectionString))
+                {
+                    CosmosClientOptions options = new() { Serializer = new CosmosModelSerializer() };
+                    CosmosClient cosmosClient = new(cosmosDbOptions.ConnectionString, options);
+                    services.AddTransient<IDynamicsStoreProvider>(
                     _ => new DynamicsStoreProvider(cosmosClient, cosmosDbOptions.DatabaseName, cosmosDbOptions.ContainerName));
+                }
+                else if (!string.IsNullOrWhiteSpace(cosmosDbOptions.AccountEndpoint))
+                {
+                    CosmosClientOptions options = new() { Serializer = new CosmosModelSerializer() };
+                    CosmosClient cosmosClient = new(cosmosDbOptions.AccountEndpoint, new DefaultAzureCredential(), options);
+                    services.AddTransient<IDynamicsStoreProvider>(
+                    _ => new DynamicsStoreProvider(cosmosClient, cosmosDbOptions.DatabaseName, cosmosDbOptions.ContainerName));
+                }
+                else
+                {
+                    throw new InvalidOperationException("No connection string or account endpoint for CosmosDb has been provided.");
+                }
                 
                 DynamicsOptions dynamicsOptions = context.Configuration.GetSection("Dynamics").Get<DynamicsOptions>()!;
             

--- a/src/auth/Inss.Auth.Broker/StartupConfiguration.cs
+++ b/src/auth/Inss.Auth.Broker/StartupConfiguration.cs
@@ -75,13 +75,17 @@ public class StartupConfiguration : IHostingStartup
             services.AddSingleton<ITokenSecurityProvider, TokenSecurityProvider>();
             services.AddSingleton<IAuthCodeStoreProvider>(_ =>
             {
-                if (!string.IsNullOrWhiteSpace(cosmosDbOptions.ConnectionString) ||
-                    !string.IsNullOrWhiteSpace(cosmosDbOptions.AccountEndpoint))
+                if (!string.IsNullOrWhiteSpace(cosmosDbOptions.ConnectionString))
                 {
                     CosmosClientOptions options = new() { Serializer = new CosmosModelSerializer() };
-                    CosmosClient client = cosmosDbOptions.ConnectionString is not null
-                        ? new CosmosClient(cosmosDbOptions.ConnectionString, options)
-                        : new CosmosClient(cosmosDbOptions.AccountEndpoint, new DefaultAzureCredential(), options);
+                    CosmosClient client = new(cosmosDbOptions.ConnectionString, options);
+                    return new CosmosAuthCodeStoreProvider(client, cosmosDbOptions.DatabaseName, cosmosDbOptions.ContainerName);
+                }
+
+                if (!string.IsNullOrWhiteSpace(cosmosDbOptions.AccountEndpoint))
+                {
+                    CosmosClientOptions options = new() { Serializer = new CosmosModelSerializer() };
+                    CosmosClient client = new(cosmosDbOptions.AccountEndpoint, new DefaultAzureCredential(), options);
                     return new CosmosAuthCodeStoreProvider(client, cosmosDbOptions.DatabaseName, cosmosDbOptions.ContainerName);
                 }
 

--- a/src/engine/GovUk.Forms.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/engine/GovUk.Forms.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -21,13 +21,19 @@ public static class ServiceCollectionExtensions
 
             services.AddSingleton<IFormStorageProvider>(provider =>
             {
-                if (!string.IsNullOrWhiteSpace(cosmosDbOptions.ConnectionString) ||
-                    !string.IsNullOrWhiteSpace(cosmosDbOptions.AccountEndpoint))
+                if (!string.IsNullOrWhiteSpace(cosmosDbOptions.ConnectionString))
                 {
                     CosmosClientOptions options = new() { Serializer = new CosmosModelSerializer() };
-                    CosmosClient client = cosmosDbOptions.ConnectionString is not null
-                        ? new CosmosClient(cosmosDbOptions.ConnectionString, options)
-                        : new CosmosClient(cosmosDbOptions.AccountEndpoint, new DefaultAzureCredential(), options);
+                    CosmosClient client = new(cosmosDbOptions.ConnectionString, options);
+                    IHttpContextAccessor httpContextAccessor = provider.GetRequiredService<IHttpContextAccessor>();
+                    return new CosmosFormStorageProvider(
+                        client, cosmosDbOptions.DatabaseName, cosmosDbOptions.ContainerName, httpContextAccessor);
+                }
+
+                if (!string.IsNullOrWhiteSpace(cosmosDbOptions.AccountEndpoint))
+                {
+                    CosmosClientOptions options = new() { Serializer = new CosmosModelSerializer() };
+                    CosmosClient client = new(cosmosDbOptions.AccountEndpoint, new DefaultAzureCredential(), options);
                     IHttpContextAccessor httpContextAccessor = provider.GetRequiredService<IHttpContextAccessor>();
                     return new CosmosFormStorageProvider(
                         client, cosmosDbOptions.DatabaseName, cosmosDbOptions.ContainerName, httpContextAccessor);


### PR DESCRIPTION
- Apps need to user the account endpoint in AZ for support the RBAC managed identities
- Local apps using the emulator still use the connection string