### PR TITLE
MEDS-1207-fixed-search-dashes-and-wildcards-issue

### DIFF
--- a/src/apps/Inss.GovUk.Forms.Fip/Inss.GovUk.Forms.Fip.csproj
+++ b/src/apps/Inss.GovUk.Forms.Fip/Inss.GovUk.Forms.Fip.csproj
@@ -13,4 +13,8 @@
       <Folder Include="App\" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
+    </ItemGroup>
+
 </Project>

--- a/src/apps/Inss.GovUk.Forms.Fip/appsettings.fip.json
+++ b/src/apps/Inss.GovUk.Forms.Fip/appsettings.fip.json
@@ -7,8 +7,8 @@
   },
   "AllowedHosts": "*",
   "Analytics": {
-    "Url": "",
-    "SiteId": "",
+    "Url": "https://app.rybbit.io/api/script.js",
+    "SiteId": "cccfbbe9bdb4",
     "SecurityHash": "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw=' 'sha256-+MPr4O+XRBNAduB7gNJMvYtSAF5bNPiBYOUmvIx/CSA='"
   },
   "Header": {
@@ -40,10 +40,12 @@
     "ContainerName": ""
   },
   "FIPSearch": {
-    "Endpoint": "https://srch-fip-spikes.search.windows.net",
-    "IndexName": "search-fip-index",
+    //"Endpoint": "https://srch-fip-spikes.search.windows.net", // srch-fip-spikes
+    "Endpoint": "https://srch-inss-dev.search.windows.net", // srch-inss-dev
+    "IndexName": "inssight-index", //"search-fip-index",
     "ApiKey": "USER SECRETS",
     "ApiVersion": "2024-07-01",
     "ConfigPath": "App/Search/FindIP.json"
+    //"UseMock":  true
   }
 }

--- a/src/engine/GovUk.Forms.Infrastructure/Clients/AzureSearchClient.cs
+++ b/src/engine/GovUk.Forms.Infrastructure/Clients/AzureSearchClient.cs
@@ -25,7 +25,7 @@ public sealed class AzureSearchClient : ISearchClient
 
     public async Task<SearchResponse> SearchAsync(SearchRequest request)
     {
-        SearchOptions searchOptions = new() { Size = request.PageSize, Skip = request.Skip, IncludeTotalCount = true };
+        SearchOptions searchOptions = new() { Size = request.PageSize, Skip = request.Skip, IncludeTotalCount = true, QueryType = SearchQueryType.Full };
 
         Response<SearchResults<SearchDocument>> response = 
             await _searchClient.SearchAsync<SearchDocument>(request.SearchText, searchOptions);


### PR DESCRIPTION
Fixed search issues...now uses SearchQueryType.Full (instead of simple query type).
This is used in conjunction with using the en.microsoft analyser in the search Index.

This branch also includes Chantelle's addition of Rybitt analytics configuration.